### PR TITLE
correcting diskbb and bkg-scaling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ gpjax = "^0.7.2"
 jaxopt = "^0.8.1"
 tinygp = "^0.3.0"
 seaborn = "^0.13.1"
+mkdocstrings = "^0.24.0"
 
 
 [tool.poetry.group.docs.dependencies]

--- a/src/jaxspec/analysis/results.py
+++ b/src/jaxspec/analysis/results.py
@@ -343,7 +343,7 @@ class ChainResult:
                     folding_model.out_energies,
                     y_observed=folding_model.folded_background.data,
                     y_samples=bkg_count,
-                    denominator=denominator,
+                    denominator=denominator / folding_model.backratio.data,
                     color=(0.26787604, 0.60085972, 0.63302651),
                     percentile=percentile,
                 )

--- a/src/jaxspec/data/obsconf.py
+++ b/src/jaxspec/data/obsconf.py
@@ -73,6 +73,7 @@ class ObsConfiguration(xr.Dataset):
             pha.quality,
             pha.exposure,
             background=bkg.counts if bkg is not None else None,
+            backratio=pha.backscal / bkg.backscal if bkg is not None else 1.0,
             attributes=metadata,
         )
 
@@ -122,6 +123,7 @@ class ObsConfiguration(xr.Dataset):
                 "transfer_matrix": transfer_matrix,
                 "area": instrument.area.copy().where(col_idx, drop=True),
                 "exposure": observation.exposure,
+                "backratio": observation.backratio,
                 "folded_counts": folded_counts,
                 "folded_background": folded_background,
             }

--- a/src/jaxspec/data/ogip.py
+++ b/src/jaxspec/data/ogip.py
@@ -23,6 +23,8 @@ class DataPHA:
         backfile=None,
         respfile=None,
         ancrfile=None,
+        backscal=1.0,
+        areascal=1.0,
     ):
         self.channel = channel
         self.counts = counts
@@ -32,6 +34,8 @@ class DataPHA:
         self.backfile = backfile
         self.respfile = respfile
         self.ancrfile = ancrfile
+        self.backscal = backscal
+        self.areascal = areascal
 
         if grouping is not None:
             # Indices array of beginning of each group
@@ -69,6 +73,8 @@ class DataPHA:
             "backfile": header.get("BACKFILE"),
             "respfile": header.get("RESPFILE"),
             "ancrfile": header.get("ANCRFILE"),
+            "backscal": header.get("BACKSCAL", 1.0),
+            "areascal": header.get("AREASCAL", 1.0),
         }
 
         return cls(data["CHANNEL"], data["COUNTS"], header["EXPOSURE"], **kwargs)

--- a/src/jaxspec/model/abc.py
+++ b/src/jaxspec/model/abc.py
@@ -268,8 +268,8 @@ class SpectralModel:
 
         return multiplicative_nodes
 
-    def __call__(self, pars, e_low, e_high):
-        return self.photon_flux(pars, e_low, e_high)
+    def __call__(self, pars, e_low, e_high, **kwargs):
+        return self.photon_flux(pars, e_low, e_high, **kwargs)
 
     @classmethod
     def from_component(cls, component, **kwargs) -> SpectralModel:

--- a/src/jaxspec/model/additive.py
+++ b/src/jaxspec/model/additive.py
@@ -330,6 +330,7 @@ class Cutoffpl(AdditiveComponent):
         return norm * energy ** (-alpha) * jnp.exp(-energy / beta)
 
 
+'''
 class Diskpbb(AdditiveComponent):
     r"""
     A multiple blackbody disk model where local disk temperature T(r) is proportional to $$r^{(-p)}$$,
@@ -360,6 +361,7 @@ class Diskpbb(AdditiveComponent):
         func_vmapped = jax.vmap(lambda e: integrate_interval(lambda kT: integrand(kT, e), 0, tin, n=51))
 
         return norm * (0.75 / p) * func_vmapped(energy)
+'''
 
 
 class Diskbb(AdditiveComponent):
@@ -378,11 +380,12 @@ class Diskbb(AdditiveComponent):
         norm = hk.get_parameter("norm", [], init=HaikuConstant(1))
         p = 0.75
         tin = hk.get_parameter("Tin", [], init=HaikuConstant(1))
+        tout = 0.0
 
         # Tout is set to 0 as it is evaluated at R=infinity
-        def integrand(kT, energy):
-            return 2.78e-3 * energy**2 * (kT / tin) ** (-2 / p - 1) / (jnp.exp(energy / kT) - 1)
+        def integrand(kT, e, tin, p):
+            return e**2 * (kT / tin) ** (-2 / p - 1) / (jnp.exp(e / kT) - 1)
 
-        func_vmapped = jax.vmap(lambda e: integrate_interval(lambda kT: integrand(kT, e), 0, tin, n=51))
+        integral = integrate_interval(integrand)
 
-        return norm * (0.75 / p) * func_vmapped(energy)
+        return norm * 2.78e-3 * (0.75 / p) / tin * jax.vmap(lambda e: integral(tout, tin, e, tin, p))(energy)

--- a/src/jaxspec/util/integrate.py
+++ b/src/jaxspec/util/integrate.py
@@ -9,12 +9,24 @@ References:
 * [Tanh-sinh quadrature](https://en.wikipedia.org/wiki/Tanh-sinh_quadrature) from Wikipedia
 """
 
+import jax
 import jax.numpy as jnp
 from jax.scipy.integrate import trapezoid
 from jax import Array
 
 
-def integrate_interval(func, a: float, b: float, n: int = 51) -> Array:
+def interval_weights(a, b, n):
+    # Change of variables to turn the integral from a to b into an integral from -1 to 1
+    t = jnp.linspace(-3, 3, n)
+    phi = jnp.tanh(jnp.pi / 2 * jnp.sinh(t))
+    dphi = jnp.pi / 2 * jnp.cosh(t) * (1 / jnp.cosh(jnp.pi / 2 * jnp.sinh(t)) ** 2)
+    x = (b - a) / 2 * phi + (b + a) / 2
+    dx = (b - a) / 2 * dphi
+
+    return t, x, dx
+
+
+def integrate_interval(integrand, n: int = 51):
     """
     Integrate a function over an interval [a, b] using the tanh-sinh quadrature.
 
@@ -25,16 +37,28 @@ def integrate_interval(func, a: float, b: float, n: int = 51) -> Array:
         n: The number of points to use for the quadrature
     """
 
-    # Change of variables to turn the integral from a to b into an integral from -1 to 1
-    t = jnp.linspace(-3, 3, n)
+    @jax.custom_jvp
+    def f(a, b, *args):
+        t, x, dx = interval_weights(a, b, n)
 
-    phi = jnp.tanh(jnp.pi / 2 * jnp.sinh(t))
-    dphi = jnp.pi / 2 * jnp.cosh(t) * (1 / jnp.cosh(jnp.pi / 2 * jnp.sinh(t)) ** 2)
+        return trapezoid(jnp.nan_to_num(integrand(x, *args) * dx), x=t)
 
-    x = (b - a) / 2 * phi + (b + a) / 2
-    dx = (b - a) / 2 * dphi
+    @f.defjvp
+    def f_jvp(primals, tangents):
+        a, b, *args = primals
+        a_dot, b_dot, *args_dot = tangents
 
-    return trapezoid(jnp.nan_to_num(func(x) * dx), x=t)
+        t, x, dx = interval_weights(a, b, n)
+
+        primal_out = f(a, b, *args)
+
+        # Partial derivatives along other parameters
+        jac = trapezoid(jnp.nan_to_num(jnp.asarray(jax.jacfwd(lambda args: integrand(x, *args))(args)) * dx), x=t, axis=-1)
+
+        tangent_out = -integrand(a, *args) * a_dot + integrand(b, *args) * b_dot + jac @ jnp.asarray(args_dot)
+        return primal_out, tangent_out
+
+    return f
 
 
 def integrate_positive(func, n: int = 51) -> Array:
@@ -45,6 +69,8 @@ def integrate_positive(func, n: int = 51) -> Array:
         func: The function to integrate
         n: The number of points to use for the quadrature
     """
+
+    # TODO : same treatment as in integrate_interval
     t = jnp.linspace(-3, 3, n)
 
     x = jnp.exp(jnp.pi / 2 * jnp.sinh(t))

--- a/tests/test_integrate.py
+++ b/tests/test_integrate.py
@@ -30,7 +30,7 @@ class TestIntegrate(TestCase):
         """
 
         for func, interval, result in self.func_interval_to_test:
-            assert jnp.isclose(integrate_interval(func, *interval), result)
+            assert jnp.isclose(integrate_interval(func)(*interval), result)
 
     def test_integrate_positive(self):
         """


### PR DESCRIPTION
- Correct diskbb and change the way we compute integrals to enable gradient computation with JAX 
- Adding the AREASCAL and BKGSCAL when including background in the forward model
- Automatic reparametrisation for transformed distributions in prior (e.g. LogUniform). It is much easier for NUTS to sample a Uniform variable which is then exponentiated (10^U(0, 5)) compared to a LogUniform variable

<!-- readthedocs-preview jaxspec start -->
----
📚 Documentation preview 📚: https://jaxspec--121.org.readthedocs.build/en/121/

<!-- readthedocs-preview jaxspec end -->