### PR TITLE
Factor ARF from RSP

### DIFF
--- a/src/jaxspec/data/instrument.py
+++ b/src/jaxspec/data/instrument.py
@@ -1,7 +1,10 @@
 import os
+
 import numpy as np
 import xarray as xr
+
 from matplotlib import colors
+
 from .ogip import DataARF, DataRMF
 
 
@@ -25,7 +28,15 @@ class Instrument(xr.Dataset):
     )
 
     @classmethod
-    def from_matrix(cls, redistribution_matrix, spectral_response, e_min_unfolded, e_max_unfolded, e_min_channel, e_max_channel):
+    def from_matrix(
+        cls,
+        redistribution_matrix,
+        spectral_response,
+        e_min_unfolded,
+        e_max_unfolded,
+        e_min_channel,
+        e_max_channel,
+    ):
         return cls(
             {
                 "redistribution": (
@@ -65,7 +76,7 @@ class Instrument(xr.Dataset):
         )
 
     @classmethod
-    def from_ogip_file(cls, rmf_path: str | os.PathLike, arf_path: str | os.PathLike = None):
+    def from_ogip_file(cls, rmf_path: str | os.PathLike, arf_path: str | os.PathLike | None = None):
         """
         Load the data from OGIP files.
 
@@ -83,22 +94,33 @@ class Instrument(xr.Dataset):
             specresp = rmf.matrix.sum(axis=0)
             rmf.sparse_matrix /= specresp
 
-        return cls.from_matrix(rmf.sparse_matrix, specresp, rmf.energ_lo, rmf.energ_hi, rmf.e_min, rmf.e_max)
+        return cls.from_matrix(
+            rmf.sparse_matrix, specresp, rmf.energ_lo, rmf.energ_hi, rmf.e_min, rmf.e_max
+        )
 
-    def plot_redistribution(self,
-                            xscale:str="log",
-                            yscale:str="log",
-                            cmap=None,
-                            vmin:float=1e-6,
-                            vmax:float=1e0,
-                            add_labels:bool=True,
-                            **kwargs):
+    def plot_redistribution(
+        self,
+        xscale: str = "log",
+        yscale: str = "log",
+        cmap=None,
+        vmin: float = 1e-6,
+        vmax: float = 1e0,
+        add_labels: bool = True,
+        **kwargs,
+    ):
         """
         Plot the redistribution probability matrix
 
         Parameters:
+            xscale : The scale of the x-axis.
+            yscale : The scale of the y-axis.
+            cmap : The colormap to use.
+            vmin : The minimum value for the colormap.
+            vmax : The maximum value for the colormap.
+            add_labels : Whether to add labels to the plot.
             **kwargs : `kwargs` passed to https://docs.xarray.dev/en/latest/generated/xarray.plot.pcolormesh.html#xarray.plot.pcolormesh
         """
+
         import cmasher as cmr
 
         return xr.plot.pcolormesh(
@@ -113,20 +135,17 @@ class Instrument(xr.Dataset):
             **kwargs,
         )
 
-    def plot_area(  self, 
-                    xscale:str="log",
-                    yscale:str="log",
-                    where:str="post",
-                    **kwargs):
+    def plot_area(self, xscale: str = "log", yscale: str = "log", where: str = "post", **kwargs):
         """
         Plot the effective area
 
         Parameters:
+            xscale : The scale of the x-axis.
+            yscale : The scale of the y-axis.
+            where : The position of the steps.
             **kwargs : `kwargs` passed to https://docs.xarray.dev/en/latest/generated/xarray.DataArray.plot.line.html#xarray.DataArray.plot.line
         """
 
-        return self.area.plot.step(x="e_min_unfolded", 
-                                    xscale=xscale,
-                                    yscale=yscale,
-                                    where=where, 
-                                    **kwargs)
+        return self.area.plot.step(
+            x="e_min_unfolded", xscale=xscale, yscale=yscale, where=where, **kwargs
+        )

--- a/src/jaxspec/data/instrument.py
+++ b/src/jaxspec/data/instrument.py
@@ -80,7 +80,8 @@ class Instrument(xr.Dataset):
             specresp = DataARF.from_file(arf_path).specresp
 
         else:
-            specresp = np.ones(rmf.energ_lo.shape)
+            specresp = rmf.matrix.sum(axis=0)
+            rmf.sparse_matrix /= specresp
 
         return cls.from_matrix(rmf.sparse_matrix, specresp, rmf.energ_lo, rmf.energ_hi, rmf.e_min, rmf.e_max)
 

--- a/src/jaxspec/data/instrument.py
+++ b/src/jaxspec/data/instrument.py
@@ -85,7 +85,14 @@ class Instrument(xr.Dataset):
 
         return cls.from_matrix(rmf.sparse_matrix, specresp, rmf.energ_lo, rmf.energ_hi, rmf.e_min, rmf.e_max)
 
-    def plot_redistribution(self, **kwargs):
+    def plot_redistribution(self,
+                            xscale:str="log",
+                            yscale:str="log",
+                            cmap=None,
+                            vmin:float=1e-6,
+                            vmax:float=1e0,
+                            add_labels:bool=True,
+                            **kwargs):
         """
         Plot the redistribution probability matrix
 
@@ -98,15 +105,19 @@ class Instrument(xr.Dataset):
             self.redistribution,
             x="e_max_unfolded",
             y="e_max_channel",
-            xscale="log",
-            yscale="log",
-            cmap=cmr.ember_r,
-            norm=colors.LogNorm(vmin=1e-6, vmax=1),
-            add_labels=True,
+            xscale=xscale,
+            yscale=yscale,
+            cmap=cmr.ember_r if cmap is None else cmap,
+            norm=colors.LogNorm(vmin=vmin, vmax=vmax),
+            add_labels=add_labels,
             **kwargs,
         )
 
-    def plot_area(self, **kwargs):
+    def plot_area(  self, 
+                    xscale:str="log",
+                    yscale:str="log",
+                    where:str="post",
+                    **kwargs):
         """
         Plot the effective area
 
@@ -114,4 +125,8 @@ class Instrument(xr.Dataset):
             **kwargs : `kwargs` passed to https://docs.xarray.dev/en/latest/generated/xarray.DataArray.plot.line.html#xarray.DataArray.plot.line
         """
 
-        return self.area.plot.step(x="e_min_unfolded", xscale="log", yscale="log", where="post", **kwargs)
+        return self.area.plot.step(x="e_min_unfolded", 
+                                    xscale=xscale,
+                                    yscale=yscale,
+                                    where=where, 
+                                    **kwargs)

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -96,6 +96,8 @@ def test_loading_curated_data_files_from_pha_with_explicit_files(observation):
 
 @pytest.mark.parametrize("observation", data_collection, ids=lambda m: m["name"])
 def test_plot_instruments_from_curated_data_files(observation):
+    title = observation["name"]
+
     if observation["name"] not in ["Chandra/LETGS", "IXPE/GPD"]:
         if "arf_path" in observation.keys():
             instrument = Instrument.from_ogip_file(
@@ -103,14 +105,17 @@ def test_plot_instruments_from_curated_data_files(observation):
                 arf_path=data_directory / observation["arf_path"],
             )
 
+            title += " (ARF included)"
+
         else:
             instrument = Instrument.from_ogip_file(
                 data_directory / observation["rmf_path"], arf_path=None
             )
-            assert np.isclose(instrument.area, np.ones_like(instrument.area)).all()
+
+            title += " (no ARF included)"
 
         instrument.plot_area()
-        plt.suptitle(observation["name"])
+        plt.suptitle(title)
         plt.show()
 
         if observation["name"] not in ["XRISM/Resolve", "Hitomi/SXS"]:


### PR DESCRIPTION
Factoring the RSP into an ARF and RMF. Now  `plot_redistribution()`/`plot_area()` plot the factored RMF/ARF instead of having RMF values over 1 and ARF being constant at 1.
Allowing to change the plotting parameters of `plot_redistribution()` and `plot_area()`.

Closes #159 

<!-- readthedocs-preview jaxspec start -->
----
📚 Documentation preview 📚: https://jaxspec--205.org.readthedocs.build/en/205/

<!-- readthedocs-preview jaxspec end -->