### PR TITLE
fix plot_ppc with components for fixed parameters

### DIFF
--- a/src/jaxspec/analysis/results.py
+++ b/src/jaxspec/analysis/results.py
@@ -140,9 +140,9 @@ class FitResult:
 
             if len(total_shape) < len(input_parameters[f"{module}_{parameter}"].shape):
                 # If there are only chains and draws, we reduce
-                input_parameters[f"{module}_{parameter}"] = input_parameters[
-                    f"{module}_{parameter}"
-                ][..., 0]
+                input_parameters[f"{module}_{parameter}"] = jnp.broadcast_to(
+                    input_parameters[f"{module}_{parameter}"][..., 0], total_shape
+                )
 
             else:
                 input_parameters[f"{module}_{parameter}"] = jnp.broadcast_to(


### PR DESCRIPTION
Closes #218 
The bug is due to bad broadcasting in some cases.

## Summary by Sourcery

Bug Fixes:
- Fix an issue where parameters were not broadcasted correctly when plotting with components for fixed parameters, leading to incorrect plots.

<!-- readthedocs-preview jaxspec start -->
----
📚 Documentation preview 📚: https://jaxspec--219.org.readthedocs.build/en/219/

<!-- readthedocs-preview jaxspec end -->