### PR TITLE
Migrate to uv

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,3 +11,4 @@ docs
 .cache
 .github
 .ipynb_checkpoints
+.venv

--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
+    - name: Set up Python 3.12
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     - uses: dorny/paths-filter@v3
       id: filter
       with:
@@ -38,7 +38,7 @@ jobs:
 
     - name: Test with pytest
       if: steps.filter.outputs.src == 'true' || steps.filter.outputs.pyproject == 'true'
-      run: docker run -t -v ./:/shared xspec-tests pytest --cov jaxspec --cov-report xml:/shared/coverage.xml
+      run: docker run -t -v ./:/shared xspec-tests uv run pytest --cov jaxspec --cov-report xml:/shared/coverage.xml
 
     - name: "Upload coverage to Codecov"
       if: steps.filter.outputs.src == 'true'

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,21 +13,17 @@ build:
   # These packages are needed to build docs with image optimization
   jobs:
     post_create_environment:
-      # Install poetry
-      # https://python-poetry.org/docs/#installing-manually
-      - pip install poetry
-      # Tell poetry to not use a virtual environment
-      - poetry config virtualenvs.create false
+      # Install uv
+      - pip install uv
     post_install:
       # Install dependencies with 'docs' dependency group
-      # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
-      - poetry install --with docs
+      - uv pip install -r pyproject.toml
       # Using insiders versions of mkdocs-material & mkdocstrings
-      - pip uninstall mkdocs-material -y # mkdocstrings mkdocstrings-python
-      - pip install git+https://$GH_TOKEN@github.com/squidfunk/mkdocs-material-insiders.git@9.5.36-insiders-4.53.13
-      - pip install mkdocstrings mkdocstrings-python #git+https://$GH_TOKEN@github.com/pawamoy-insiders/mkdocstrings-python.git
-      - pip install mkdocs-autorefs
-      - pip install mkdocs-jupyter # This is bugged, I enforced it manually, let's see if it works
+      - uv pip uninstall mkdocs-material # mkdocstrings mkdocstrings-python
+      - uv pip install git+https://$GH_TOKEN@github.com/squidfunk/mkdocs-material-insiders.git@9.5.36-insiders-4.53.13
+      - uv pip install mkdocstrings mkdocstrings-python
+      - uv pip install mkdocs-autorefs
+      - uv pip install mkdocs-jupyter # This is bugged, I enforced it manually, let's see if it works
 
   apt_packages:
     - libcairo2-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM renecoty/heasoft:poetry
+FROM renecoty/heasoft:v6.34
 
 WORKDIR /jaxspec
 
@@ -8,16 +8,12 @@ USER root
 RUN apt-get update && \
     apt-get install -y git
 
-RUN pip install poetry
+RUN pip install uv
 
-COPY pyproject.toml /jaxspec/
+ADD src /jaxspec/src
+ADD tests /jaxspec/tests
+ADD pyproject.toml /jaxspec/pyproject.toml
+ADD README.md /jaxspec/README.md
 
-ENV POETRY_VIRTUALENVS_IN_PROJECT=0 \
-    POETRY_VIRTUALENVS_CREATE=0 \
-    POETRY_CACHE_DIR=/tmp/poetry_cache
-
-RUN poetry install --no-root --no-ansi --no-interaction
-
-COPY . /jaxspec
-
-RUN poetry install --no-ansi --no-interaction
+RUN uv sync --no-group docs --no-group dev --python 3.12
+ENV PATH="/app/.venv/bin:$PATH"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,65 +1,79 @@
-[tool.poetry]
+[project]
 name = "jaxspec"
 version = "0.2.2dev"
 description = "jaxspec is a bayesian spectral fitting library for X-ray astronomy."
-authors = ["sdupourque <sdupourque@irap.omp.eu>"]
-license = "MIT"
+authors = [{ name = "sdupourque", email = "sdupourque@irap.omp.eu" }]
+requires-python = ">=3.10,<3.13"
 readme = "README.md"
-homepage = "https://github.com/renecotyfanboy/jaxspec"
-documentation = "https://jaxspec.readthedocs.io/en/latest/"
+license = "MIT"
+dependencies = [
+    "jax>=0.5.0,<0.6",
+    "numpy<2.0.0",
+    "pandas>=2.2.0,<3",
+    "astropy>=6.0.0,<7",
+    "numpyro>=0.17.0,<0.18",
+    "networkx~=3.1",
+    "matplotlib>=3.8.0,<4",
+    "arviz>=0.17.1,<0.21.0",
+    "chainconsumer>=1.1.2,<2",
+    "simpleeval>=0.9.13,<1.1.0",
+    "cmasher>=1.6.3,<2",
+    "jaxopt>=0.8.3,<0.9",
+    "tinygp>=0.3.0,<0.4",
+    "seaborn>=0.13.1,<0.14",
+    "sparse>=0.15.4,<0.16",
+    "optimistix>=0.0.10,<0.0.11",
+    "scipy<1.15",
+    "mendeleev>=0.15,<0.20",
+    "jaxns>=2.6.7,<3",
+    "pooch>=1.8.2,<2",
+    "interpax>=0.3.5,<0.4",
+    "watermark>=2.4.3,<3",
+    "catppuccin>=2.3.4,<3",
+    "flax>=0.10.3,<0.11",
+]
 
+[project.urls]
+Homepage = "https://github.com/renecotyfanboy/jaxspec"
+Documentation = "https://jaxspec.readthedocs.io/en/latest/"
 
-[tool.poetry.dependencies]
-python = ">=3.10,<3.13"
-jax = "^0.5.0"
-numpy = "<2.0.0"
-pandas = "^2.2.0"
-astropy = "^6.0.0"
-numpyro = "^0.16.1"
-networkx = "^3.1"
-matplotlib = "^3.8.0"
-arviz = ">=0.17.1,<0.21.0"
-chainconsumer = "^1.1.2"
-simpleeval = ">=0.9.13,<1.1.0"
-cmasher = "^1.6.3"
-jaxopt = "^0.8.1"
-tinygp = "^0.3.0"
-seaborn = "^0.13.1"
-sparse = "^0.15.4"
-optimistix = ">=0.0.7,<0.0.11"
-scipy = "<1.15"
-mendeleev = ">=0.15,<0.20"
-jaxns = "^2.6.7"
-pooch = "^1.8.2"
-interpax = "^0.3.3"
-watermark = "^2.4.3"
-catppuccin = "^2.3.4"
-flax = "^0.10.1"
+[project.scripts]
+jaxspec-debug-info = "jaxspec.scripts.debug:debug_info"
 
+[dependency-groups]
+docs = [
+    "mkdocs>=1.6.1,<2",
+    "mkdocs-material>=9.4.6,<10",
+    "mkdocstrings[python]>=0.24,<0.28",
+    "mkdocs-jupyter>=0.25.0,<0.26",
+]
+test = [
+    "chex>=0.1.83,<0.2",
+    "mktestdocs>=0.2.1,<0.3",
+    "coverage>=7.3.2,<8",
+    "pytest-cov>=4.1,<7.0",
+    "flake8>=7.0.0,<8",
+    "pytest>=8.0.0,<9",
+    "testbook>=0.4.2,<0.5",
+]
+dev = [
+    "pre-commit>=3.5,<5.0",
+    "ruff>=0.2.1,<0.10.0",
+    "jupyterlab>=4.0.7,<5",
+    "notebook>=7.0.6,<8",
+    "ipywidgets>=8.1.1,<9",
+]
 
-[tool.poetry.group.docs.dependencies]
-mkdocs = "^1.6.1"
-mkdocs-material = "^9.4.6"
-mkdocstrings = {extras = ["python"], version = ">=0.24,<0.28"}
-mkdocs-jupyter = "^0.25.0"
+[tool.uv]
+default-groups = [
+    "docs",
+    "test",
+    "dev",
+]
 
-
-[tool.poetry.group.test.dependencies]
-chex = "^0.1.83"
-mktestdocs = "^0.2.1"
-coverage = "^7.3.2"
-pytest-cov = ">=4.1,<7.0"
-flake8 = "^7.0.0"
-pytest = "^8.0.0"
-testbook = "^0.4.2"
-
-
-[tool.poetry.group.dev.dependencies]
-pre-commit = ">=3.5,<5.0"
-ruff = ">=0.2.1,<0.10.0"
-jupyterlab = "^4.0.7"
-notebook = "^7.0.6"
-ipywidgets = "^8.1.1"
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [tool.ruff]
 line-length = 100
@@ -109,10 +123,3 @@ lines-between-types = 1
   "F401", # Module imported but unused
   "F403", # 'from module import *' used; unable to detect undefined names
 ]
-
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
-
-[tool.poetry.scripts]
-jaxspec-debug-info = "jaxspec.scripts.debug:debug_info"


### PR DESCRIPTION
## Summary by Sourcery

Migrate the project build system from Poetry to Hatch, using uv as the dependency manager. Update the ReadTheDocs build configuration accordingly.

Build:
- Migrate from `poetry` to `hatch` as the build backend.
- Update `pyproject.toml` to `hatch` standards, including dependency specifications and project metadata.
- Add `uv` as a dependency manager for development tasks and documentation builds.
- Update the ReadTheDocs configuration to use `uv` for dependency management and installation steps during documentation builds

Documentation:
- Update the ReadTheDocs configuration to use `uv` for dependency management and installation steps during documentation builds

<!-- readthedocs-preview jaxspec start -->
----
📚 Documentation preview 📚: https://jaxspec--225.org.readthedocs.build/en/225/

<!-- readthedocs-preview jaxspec end -->