### PR TITLE
Fixed RSP loading and added small functionalities

### DIFF
--- a/src/jaxspec/analysis/results.py
+++ b/src/jaxspec/analysis/results.py
@@ -434,6 +434,7 @@ class FitResult:
         title: str | None = None,
         figsize: tuple[float, float] = (6, 6),
         x_lims: tuple[float, float] | None = None,
+        rescale_background: bool = False,
     ) -> list[plt.Figure]:
         r"""
         Plot the posterior predictive distribution of the model. It also features a residual plot, defined using the
@@ -454,6 +455,7 @@ class FitResult:
             title: The title of the plot.
             figsize: The size of the figure.
             x_lims: The limits of the x-axis.
+            rescale_background: Whether to rescale the background model to the data with backscal ratio.
 
         Returns:
             A list of matplotlib figures for each observation in the model.
@@ -604,10 +606,12 @@ class FitResult:
                         )
                     )
 
+                    rescale_background_factor = obsconf.folded_backratio.data if rescale_background else 1.
+
                     model_bkg_plot = _plot_binned_samples_with_error(
                         ax[0],
                         xbins.value,
-                        y_samples_bkg.value,
+                        y_samples_bkg.value * rescale_background_factor,
                         color=BACKGROUND_COLOR,
                         alpha_envelope=alpha_envelope,
                         n_sigmas=n_sigmas,
@@ -616,9 +620,9 @@ class FitResult:
                     true_bkg_plot = _plot_poisson_data_with_error(
                         ax[0],
                         xbins.value,
-                        y_observed_bkg.value,
-                        y_observed_bkg_low.value,
-                        y_observed_bkg_high.value,
+                        y_observed_bkg.value * rescale_background_factor,
+                        y_observed_bkg_low.value * rescale_background_factor,
+                        y_observed_bkg_high.value * rescale_background_factor,
                         color=BACKGROUND_DATA_COLOR,
                         alpha=0.7,
                     )

--- a/src/jaxspec/data/instrument.py
+++ b/src/jaxspec/data/instrument.py
@@ -1,4 +1,5 @@
 import os
+import sparse
 
 import numpy as np
 import xarray as xr
@@ -92,7 +93,7 @@ class Instrument(xr.Dataset):
 
         else:
             specresp = rmf.matrix.sum(axis=0)
-            rmf.sparse_matrix /= specresp
+            rmf.sparse_matrix = sparse.COO( rmf.matrix / specresp )
 
         return cls.from_matrix(
             rmf.sparse_matrix, specresp, rmf.energ_lo, rmf.energ_hi, rmf.e_min, rmf.e_max


### PR DESCRIPTION
Fixed the RSP loading, which was bugged because of sparse-dense operation happening.

Added the functionality to rescale background with the backscale ratio in the posterior predictive plots.

Added the 'full', 'obs/~/all' and 'bkg/~/all' arrays in the inference_data.log_likelihood dictionary. This is useful for arviz model comparison when fitting multiple instruments.

<!-- readthedocs-preview jaxspec start -->
----
📚 Documentation preview 📚: https://jaxspec--253.org.readthedocs.build/en/253/

<!-- readthedocs-preview jaxspec end -->