### PR TITLE
Adding pileup computation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ default-groups = [
 markers = [
     "slow: marks tests as slow, typically involving MCMC inference or external tools (deselect with '-m \"not slow\"')",
     "fast: marks tests as fast, suitable for quick iteration",
+    "xspec: marks tests that compare against a live PyXSPEC/HEASOFT install (run with 'bash scripts/run_xspec_tests.sh')",
 ]
 
 [build-system]

--- a/src/jaxspec/model/instrument.py
+++ b/src/jaxspec/model/instrument.py
@@ -267,10 +267,6 @@ class PileupModel(InstrumentModel):
         if eval_energies is None:
             raise ValueError("Eval energies cannot be None : an energy grid must be provided")
 
-        diffs = np.diff(eval_energies, axis=0)
-        if not np.allclose(diffs, diffs.mean()):
-            raise ValueError("eval_energies must be linearly spaced")
-
         eval_energies = self.apply_shift(eval_energies)
         spectrum = jax.tree.map(
             lambda s: redistribute(s, *eval_energies, *cache["in_energies"]), spectrum

--- a/src/jaxspec/model/instrument.py
+++ b/src/jaxspec/model/instrument.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 
 from flax import nnx
 from jax.typing import ArrayLike
@@ -194,8 +195,8 @@ class PileupModel(InstrumentModel):
     )
     ```
 
-    `alpha` and `psf_frac` are **fitted** parameters (`nnx.Param` leaves) whose
-    priors are supplied through the unified prior dict like any other instrument
+    `alpha` and `psf_frac` are **fitted** parameters whose
+    priors are supplied through the prior dictionary like any other instrument
     parameter, e.g. ``"instrument.alpha"`` and ``"instrument.psf_frac"`` (see
     [`MCMCFitter`][jaxspec.fit.MCMCFitter]). The remaining arguments are **fixed**
     configuration constants.
@@ -228,15 +229,22 @@ class PileupModel(InstrumentModel):
 
     requires_components = True
 
-    def __init__(self, gain: GainModel | None = None, shift: ShiftModel | None = None, **kwargs):
+    def __init__(
+        self,
+        gain: GainModel | None = None,
+        shift: ShiftModel | None = None,
+        frac_expo: float | None = None,
+        frame_time: float | None = None,
+        num_regions: float | None = 1.0,
+        g0: float | None = 1.0,
+        npiled: int | None = 5,
+    ):
         super().__init__(gain=gain, shift=shift)
 
-        frac_expo = kwargs.get("frac_expo")
-        frame_time = kwargs.get("frame_time")
         if frac_expo is None or frame_time is None:
             raise ValueError(
                 "PileupModel requires both `frac_expo` and `frame_time` keyword arguments "
-                "(the Chandra 'FRACEXPO' and 'EXPTIME' header values)."
+                "(the 'FRACEXPO' and 'EXPTIME' header values)."
             )
 
         self.alpha = nnx.Param(jnp.asarray(0.5))
@@ -245,9 +253,9 @@ class PileupModel(InstrumentModel):
         self._constants = {
             "frac_expo": frac_expo,
             "frame_time": frame_time,
-            "num_regions": kwargs.get("num_regions", 1.0),
-            "g0": kwargs.get("g0", 1.0),
-            "npiled": int(kwargs.get("npiled", 5)),
+            "num_regions": num_regions,
+            "g0": g0,
+            "npiled": int(np.rint(npiled)),
         }
 
     def fold(
@@ -259,16 +267,15 @@ class PileupModel(InstrumentModel):
         if eval_energies is None:
             raise ValueError("Eval energies cannot be None : an energy grid must be provided")
 
-        # ARF convolution
-        # cache["redistribution"] = to_jax_matrix(obs.redistribution.data, sparse=sparse)
-        # cache["grouping"] = to_jax_matrix(obs.grouping.data, sparse=sparse)
-        # cache["area"] = jnp.asarray(obs.area.data)
-        # cache["exposure"] = jnp.asarray(obs.exposure.data)
+        diffs = np.diff(eval_energies, axis=0)
+        if not np.allclose(diffs, diffs.mean()):
+            raise ValueError("eval_energies must be linearly spaced")
 
         eval_energies = self.apply_shift(eval_energies)
         spectrum = jax.tree.map(
             lambda s: redistribute(s, *eval_energies, *cache["in_energies"]), spectrum
         )
+
         num_regions = self._constants["num_regions"]
         fracexpo = self._constants["frac_expo"]
         frame_time = self._constants["frame_time"]
@@ -279,8 +286,7 @@ class PileupModel(InstrumentModel):
         # Offset required in case the energy grid does not start at zero
         # (the energy grid is assumed uniform, so the first bin width sets the offset).
         bin_width = in_energies[0, 1] - in_energies[0, 0]
-        ioff = -jnp.array(in_energies[0, 0] // bin_width, jnp.int32)
-        # Vectorised offset gather (see below): built once and shared across branches.
+        ioff = -jnp.array(in_energies[0, 0] // bin_width, jnp.int_)
         n_orig = in_energies.shape[1]
         shift_idx = jnp.arange(n_orig) + ioff
 
@@ -307,10 +313,7 @@ class PileupModel(InstrumentModel):
             arf_s_fft = jnp.fft.rfft(arf_s_tmp)
             factor = 1
 
-            # Compute FFT with offset. ``arf_s_tmp[shift_idx]`` is the vectorised
-            # equivalent of ``[arf_s_tmp[ie + ioff] for ie in range(n_orig)]`` --
-            # a single gather instead of one op per channel (bit-identical, but a
-            # far smaller XLA graph and much faster to trace/compile).
+            # Compute FFT with offset
             tmpar = arf_s_tmp[shift_idx]
             arf_s_fft_2 = jnp.fft.rfft(tmpar)
 

--- a/src/jaxspec/model/instrument.py
+++ b/src/jaxspec/model/instrument.py
@@ -148,3 +148,124 @@ class InstrumentModel(nnx.Module):
         spectrum = jax.tree.map(lambda s: self.apply_gain(s, cache["in_energies"]), spectrum)
 
         return jax.tree.map(lambda s: jnp.clip(cache["transfer_matrix"] @ s, min=1e-6), spectrum)
+        
+        
+class PileupModel(InstrumentModel):
+    """Per-observation instrument response with pileup effects included. Pileup formula from Davis 2001.
+
+    Pass as a dict to :class:`~jaxspec.fit.BayesianModel`::
+
+        BayesianModel(
+            spectral_model, prior, observations,
+            instrument_model={
+                "Chandra": PileupModel(gain=ConstantGain(), shift=ConstantShift(), **pileup_kwargs),
+            },
+        )
+
+    Parameters:
+        gain and shift: Identical to the InstrumentModel()
+
+        alpha: Grade migration factor : probability that the piled event is not rejected as "bad event"
+
+        psf_frac: Fraction of events in the source extraction region to which pileup will be applied
+
+        frame_time: frame time (of readout time) of the observation. In Chandra data it corresponds to the 'EXPTIME' keyword in the *_evt2.fits file
+
+        frac_expo: good exposure time per frame. Between 0.0 and 1.0. In Chandra data it corresponds to the 'FRACEXPO' keyword
+
+        g0: Optional. Grade correction for single photon detection, between 0.0 and 1.0. Default is 1.0
+
+        npiled: Optional. Number of photons considered for pileup in a single frame. Default is 5
+
+        num_regions: Optional. Number of regions to which pileup model will be applied independently. Default is 1.0, valid for point sources. Extended sources might require higher value.
+    """
+
+    requires_components = True
+
+    def __init__(self, gain: GainModel | None = None, shift: ShiftModel | None = None, **kwargs):
+        super().__init__(gain = gain, shift=shift)
+
+        self.alpha = nnx.Param(jnp.asarray(0.5))
+        self.psf_frac = nnx.Param(jnp.asarray(0.95))
+
+        self.constants = {
+            "frac_expo" : kwargs.get("frac_expo"),
+            "frame_time" : kwargs.get("frame_time"),
+            "num_regions" : kwargs.get("num_regions", 1.0),
+            "g0" : kwargs.get("g0", 1.0),
+            "npiled" : kwargs.get("npiled", 5.0),
+        }
+
+    def fold(
+        self,
+        spectrum: ArrayLike,
+        cache: dict,
+        eval_energies : ArrayLike | None=None,
+    ):
+
+        if eval_energies is None:
+            raise ValueError("Eval energies cannot be None : an energy grid must be provided")
+
+        # ARF convolution
+        # cache["redistribution"] = to_jax_matrix(obs.redistribution.data, sparse=sparse)
+        # cache["grouping"] = to_jax_matrix(obs.grouping.data, sparse=sparse)
+        # cache["area"] = jnp.asarray(obs.area.data)
+        # cache["exposure"] = jnp.asarray(obs.exposure.data)
+
+        eval_energies = self.apply_shift(eval_energies)
+        spectrum = jax.tree.map(lambda s: redistribute(s, *eval_energies, *cache["in_energies"]), spectrum)
+        arf_s = jax.tree.map(lambda f: f * cache["area"], spectrum)
+
+        num_regions = self.constants["num_regions"]
+        fracexpo = self.constants["frac_expo"]
+        frame_time = self.constants["frame_time"]
+        g0 = self.constants["g0"]
+        npiled = self.constants["npiled"]
+
+        # Calculate pileup following original algorithm
+        psf_frac = self.psf_frac / num_regions / fracexpo
+        arf_s_tmp = arf_s * psf_frac
+        integ_arf_s = jnp.sum(arf_s_tmp)
+
+        results = arf_s * psf_frac  # term p=1 of the sum
+
+        exp_factor = jnp.exp(-frame_time * integ_arf_s / g0)
+        exp_factor *= num_regions * fracexpo
+
+        # Normalize to avoid overflow and perform FFT convolutions
+        arf_s_tmp /= integ_arf_s
+        integ_arf_s_n = integ_arf_s  ## for renormalization after
+        n_orig = arf_s_tmp.shape[-1]
+        arf_s_fft = jnp.fft.rfft(arf_s_tmp)
+        factor = 1
+
+        # Offset required in case the energy grid does not start at zero
+        ioff = -int(cache["in_energies"][0,0] // (cache["in_energies"][0,1] - cache["in_energies"][0,0])) 
+        
+        # Compute FFT with offset
+        tmpar = jnp.array([arf_s_tmp[ie + ioff] for ie in range(n_orig)])
+        arf_s_fft_2 = jnp.fft.rfft(tmpar)
+
+        # Calculate higher order terms
+        for i in range(2, npiled + 1):
+
+            integ_arf_s_n *= integ_arf_s   #renormalization factor
+
+            # Convolution via FFT
+            arf_s_tmp = jnp.fft.irfft(arf_s_fft * arf_s_fft_2 ** (i-1), n=n_orig)
+            arf_s_tmp = jnp.clip(arf_s_tmp, min=0)
+            
+            # Apply grade migration factor
+            factor *= self.alpha * frame_time / i
+            results += factor * integ_arf_s_n * arf_s_tmp 
+
+        # Apply final corrections
+        results *= exp_factor
+
+        # Handle non-piled fraction
+        remaining_frac = 1.0 - self.psf_frac
+        results += arf_s * jnp.clip(remaining_frac, min=0)
+
+        spectrum = self.apply_gain(results, cache["in_energies"])
+
+        return jax.tree.map(lambda s: jnp.clip(cache["grouping"] @ cache["redistribution"] @ s * cache["exposure"] , min=1e-10), spectrum)

--- a/src/jaxspec/model/instrument.py
+++ b/src/jaxspec/model/instrument.py
@@ -148,8 +148,8 @@ class InstrumentModel(nnx.Module):
         spectrum = jax.tree.map(lambda s: self.apply_gain(s, cache["in_energies"]), spectrum)
 
         return jax.tree.map(lambda s: jnp.clip(cache["transfer_matrix"] @ s, min=1e-6), spectrum)
-        
-        
+
+
 class PileupModel(InstrumentModel):
     """Per-observation instrument response with pileup effects included. Pileup formula from Davis 2001.
 
@@ -183,26 +183,33 @@ class PileupModel(InstrumentModel):
     requires_components = True
 
     def __init__(self, gain: GainModel | None = None, shift: ShiftModel | None = None, **kwargs):
-        super().__init__(gain = gain, shift=shift)
+        super().__init__(gain=gain, shift=shift)
+
+        frac_expo = kwargs.get("frac_expo")
+        frame_time = kwargs.get("frame_time")
+        if frac_expo is None or frame_time is None:
+            raise ValueError(
+                "PileupModel requires both `frac_expo` and `frame_time` keyword arguments "
+                "(the Chandra 'FRACEXPO' and 'EXPTIME' header values)."
+            )
 
         self.alpha = nnx.Param(jnp.asarray(0.5))
         self.psf_frac = nnx.Param(jnp.asarray(0.95))
 
-        self.constants = {
-            "frac_expo" : kwargs.get("frac_expo"),
-            "frame_time" : kwargs.get("frame_time"),
-            "num_regions" : kwargs.get("num_regions", 1.0),
-            "g0" : kwargs.get("g0", 1.0),
-            "npiled" : kwargs.get("npiled", 5.0),
+        self._constants = {
+            "frac_expo": frac_expo,
+            "frame_time": frame_time,
+            "num_regions": kwargs.get("num_regions", 1.0),
+            "g0": kwargs.get("g0", 1.0),
+            "npiled": int(kwargs.get("npiled", 5)),
         }
 
     def fold(
         self,
         spectrum: ArrayLike,
         cache: dict,
-        eval_energies : ArrayLike | None=None,
+        eval_energies: ArrayLike | None = None,
     ):
-
         if eval_energies is None:
             raise ValueError("Eval energies cannot be None : an energy grid must be provided")
 
@@ -213,59 +220,73 @@ class PileupModel(InstrumentModel):
         # cache["exposure"] = jnp.asarray(obs.exposure.data)
 
         eval_energies = self.apply_shift(eval_energies)
-        spectrum = jax.tree.map(lambda s: redistribute(s, *eval_energies, *cache["in_energies"]), spectrum)
-        arf_s = jax.tree.map(lambda f: f * cache["area"], spectrum)
+        spectrum = jax.tree.map(
+            lambda s: redistribute(s, *eval_energies, *cache["in_energies"]), spectrum
+        )
+        num_regions = self._constants["num_regions"]
+        fracexpo = self._constants["frac_expo"]
+        frame_time = self._constants["frame_time"]
+        g0 = self._constants["g0"]
+        npiled = self._constants["npiled"]
 
-        num_regions = self.constants["num_regions"]
-        fracexpo = self.constants["frac_expo"]
-        frame_time = self.constants["frame_time"]
-        g0 = self.constants["g0"]
-        npiled = self.constants["npiled"]
-
-        # Calculate pileup following original algorithm
-        psf_frac = self.psf_frac / num_regions / fracexpo
-        arf_s_tmp = arf_s * psf_frac
-        integ_arf_s = jnp.sum(arf_s_tmp)
-
-        results = arf_s * psf_frac  # term p=1 of the sum
-
-        exp_factor = jnp.exp(-frame_time * integ_arf_s / g0)
-        exp_factor *= num_regions * fracexpo
-
-        # Normalize to avoid overflow and perform FFT convolutions
-        arf_s_tmp /= integ_arf_s
-        integ_arf_s_n = integ_arf_s  ## for renormalization after
-        n_orig = arf_s_tmp.shape[-1]
-        arf_s_fft = jnp.fft.rfft(arf_s_tmp)
-        factor = 1
-
+        in_energies = cache["in_energies"]
         # Offset required in case the energy grid does not start at zero
-        ioff = - jnp.array(cache["in_energies"][0,0] // (cache["in_energies"][0,1] - cache["in_energies"][0,0]), jnp.int64)
-        
-        # Compute FFT with offset
-        tmpar = jnp.array([arf_s_tmp[ie + ioff] for ie in range(n_orig)])
-        arf_s_fft_2 = jnp.fft.rfft(tmpar)
+        # (the energy grid is assumed uniform, so the first bin width sets the offset).
+        bin_width = in_energies[0, 1] - in_energies[0, 0]
+        ioff = -jnp.array(in_energies[0, 0] // bin_width, jnp.int32)
 
-        # Calculate higher order terms
-        for i in range(2, npiled + 1):
+        def pileup_fold(s):
+            # The pileup math operates on a single spectrum; ``jax.tree.map``
+            # below applies it per branch when the forward model requests a
+            # split-branch fold (e.g. posterior-predictive overlays), mirroring
+            # the base ``InstrumentModel.fold`` pytree contract.
+            arf_s = s * cache["area"]
 
-            integ_arf_s_n *= integ_arf_s   #renormalization factor
+            # Calculate pileup following original algorithm
+            psf_frac = self.psf_frac / num_regions / fracexpo
+            arf_s_tmp = arf_s * psf_frac
+            integ_arf_s = jnp.sum(arf_s_tmp)
 
-            # Convolution via FFT
-            arf_s_tmp = jnp.fft.irfft(arf_s_fft * arf_s_fft_2 ** (i-1), n=n_orig)
-            arf_s_tmp = jnp.clip(arf_s_tmp, min=0)
-            
-            # Apply grade migration factor
-            factor *= self.alpha * frame_time / i
-            results += factor * integ_arf_s_n * arf_s_tmp 
+            results = arf_s * psf_frac  # term p=1 of the sum
 
-        # Apply final corrections
-        results *= exp_factor
+            exp_factor = jnp.exp(-frame_time * integ_arf_s / g0)
+            exp_factor = exp_factor * num_regions * fracexpo
 
-        # Handle non-piled fraction
-        remaining_frac = 1.0 - self.psf_frac
-        results += arf_s * jnp.clip(remaining_frac, min=0)
+            # Normalize to avoid overflow and perform FFT convolutions
+            arf_s_tmp = arf_s_tmp / integ_arf_s
+            integ_arf_s_n = integ_arf_s  # for renormalization after
+            n_orig = arf_s_tmp.shape[-1]
+            arf_s_fft = jnp.fft.rfft(arf_s_tmp)
+            factor = 1
 
-        spectrum = self.apply_gain(results, cache["in_energies"])
+            # Compute FFT with offset
+            tmpar = jnp.array([arf_s_tmp[ie + ioff] for ie in range(n_orig)])
+            arf_s_fft_2 = jnp.fft.rfft(tmpar)
 
-        return jax.tree.map(lambda s: jnp.clip(cache["grouping"] @ cache["redistribution"] @ s * cache["exposure"] , min=1e-10), spectrum)
+            # Calculate higher order terms
+            for i in range(2, npiled + 1):
+                integ_arf_s_n = integ_arf_s_n * integ_arf_s  # renormalization factor
+
+                # Convolution via FFT
+                conv = jnp.fft.irfft(arf_s_fft * arf_s_fft_2 ** (i - 1), n=n_orig)
+                conv = jnp.clip(conv, min=0)
+
+                # Apply grade migration factor
+                factor = factor * self.alpha * frame_time / i
+                results = results + factor * integ_arf_s_n * conv
+
+            # Apply final corrections
+            results = results * exp_factor
+
+            # Handle non-piled fraction
+            remaining_frac = 1.0 - self.psf_frac
+            results = results + arf_s * jnp.clip(remaining_frac, min=0)
+
+            results = self.apply_gain(results, in_energies)
+
+            return jnp.clip(
+                cache["grouping"] @ cache["redistribution"] @ results * cache["exposure"],
+                min=1e-10,
+            )
+
+        return jax.tree.map(pileup_fold, spectrum)

--- a/src/jaxspec/model/instrument.py
+++ b/src/jaxspec/model/instrument.py
@@ -240,7 +240,7 @@ class PileupModel(InstrumentModel):
         factor = 1
 
         # Offset required in case the energy grid does not start at zero
-        ioff = -int(cache["in_energies"][0,0] // (cache["in_energies"][0,1] - cache["in_energies"][0,0])) 
+        ioff = - jnp.array(cache["in_energies"][0,0] // (cache["in_energies"][0,1] - cache["in_energies"][0,0]), jnp.int64)
         
         # Compute FFT with offset
         tmpar = jnp.array([arf_s_tmp[ie + ioff] for ie in range(n_orig)])

--- a/src/jaxspec/model/instrument.py
+++ b/src/jaxspec/model/instrument.py
@@ -69,19 +69,21 @@ class ConstantShift(ShiftModel):
 class InstrumentModel(nnx.Module):
     """Per-observation instrument response.
 
-    Pass as a dict to :class:`~jaxspec.fit.BayesianModel`::
+    Pass as a dict to [`BayesianModel`][jaxspec.fit.BayesianModel]
 
-        BayesianModel(
-            spectral_model, prior, observations,
-            instrument_model={
-                "PN": None, # explicit reference
-                "MOS1": InstrumentModel(gain=ConstantGain(), shift=ConstantShift()),
-                "MOS2": InstrumentModel(gain=ConstantGain(), shift=ConstantShift()),
-            },
-        )
+    ```python
+    BayesianModel(
+        spectral_model, prior, observations,
+        instrument_model={
+            "PN": None, # explicit reference
+            "MOS1": InstrumentModel(gain=ConstantGain(), shift=ConstantShift()),
+            "MOS2": InstrumentModel(gain=ConstantGain(), shift=ConstantShift()),
+        },
+    )
+    ```
 
     ``None`` entries (or simply omitting an observation) apply the identity
-    fold (``transfer_matrix @ flux``) — useful for the reference instrument.
+    fold (``transfer_matrix @ flux``), this allows to specify the reference instruments.
 
     Parameters:
         gain: Optional :class:`GainModel` (e.g. :class:`ConstantGain`). When
@@ -151,33 +153,77 @@ class InstrumentModel(nnx.Module):
 
 
 class PileupModel(InstrumentModel):
-    """Per-observation instrument response with pileup effects included. Pileup formula from Davis 2001.
+    """Per-observation instrument response including CCD photon **pile-up**.
 
-    Pass as a dict to :class:`~jaxspec.fit.BayesianModel`::
+    The `jaxspec` counterpart of `XSPEC`
+    [`pileup`](https://heasarc.gsfc.nasa.gov/docs/software/xspec/manual/XSmodelPileup.html)
+    convolution model ([Davis 2001](https://iopscience.iop.org/article/10.1086/323488/pdf)) which
+    describes the mixing of photons that reach the same detector region within a
+    single CCD frame, the dominant calibration effect for bright point sources on
+    instruments such as Chandra/ACIS. [`PileupModel`][jaxspec.model.instrument.PileupModel] extends
+    [`InstrumentModel`][jaxspec.model.instrument.InstrumentModel]: pile-up is
+    applied to the effective-area–weighted (ARF) spectrum, *before* the
+    redistribution matrix (RMF) and grouping, matching the ordering of the XSPEC
+    `pileup` model.
 
-        BayesianModel(
-            spectral_model, prior, observations,
-            instrument_model={
-                "Chandra": PileupModel(gain=ConstantGain(), shift=ConstantShift(), **pileup_kwargs),
-            },
-        )
+    !!! warning
+        [`PileupModel`][jaxspec.model.instrument.PileupModel] requires an explicit and linear evaluation
+        grid (pass ``energy_grid=jnp.linspace(low, high, n_bins)`` to the fitter /
+        [`BayesianModel`][jaxspec.fit.BayesianModel]).
+
+    Pass it per observation just like a plain
+    [`InstrumentModel`][jaxspec.model.instrument.InstrumentModel]:
+
+    ```python
+    from jaxspec.fit import MCMCFitter
+    from jaxspec.model.instrument import ConstantGain, ConstantShift, PileupModel
+
+    fitter = MCMCFitter(
+        spectral_model,
+        prior,
+        observations,
+        energy_grid=np.linspace(0.2, 11.0, 1_000),
+        instrument_model={
+            "ACIS": PileupModel(
+                gain=ConstantGain(),
+                shift=ConstantShift(),
+                frame_time=3.2,  # CCD frame time / ACIS EXPTIME (s)
+                frac_expo=1.0,  # ARF FRACEXPO keyword
+            ),
+        },
+    )
+    ```
+
+    `alpha` and `psf_frac` are **fitted** parameters (`nnx.Param` leaves) whose
+    priors are supplied through the unified prior dict like any other instrument
+    parameter, e.g. ``"instrument.alpha"`` and ``"instrument.psf_frac"`` (see
+    [`MCMCFitter`][jaxspec.fit.MCMCFitter]). The remaining arguments are **fixed**
+    configuration constants.
+
+    !!! note
+        Pile-up is **non-linear** in flux: as noted in the
+        [XSPEC `pileup` documentation](https://heasarc.gsfc.nasa.gov/docs/software/xspec/manual/XSmodelPileup.html),
+        increasing the source normalisation does not scale the predicted count
+        rate linearly, and fluxes should be computed with the pile-up correction
+        removed. The extraction region should be large enough to contain
+        essentially all of the point-source PSF.
 
     Parameters:
-        gain and shift: Identical to the InstrumentModel()
-
-        alpha: Grade migration factor : probability that the piled event is not rejected as "bad event"
-
-        psf_frac: Fraction of events in the source extraction region to which pileup will be applied
-
-        frame_time: frame time (of readout time) of the observation. In Chandra data it corresponds to the 'EXPTIME' keyword in the *_evt2.fits file
-
-        frac_expo: good exposure time per frame. Between 0.0 and 1.0. In Chandra data it corresponds to the 'FRACEXPO' keyword
-
-        g0: Optional. Grade correction for single photon detection, between 0.0 and 1.0. Default is 1.0
-
-        npiled: Optional. Number of photons considered for pileup in a single frame. Default is 5
-
-        num_regions: Optional. Number of regions to which pileup model will be applied independently. Default is 1.0, valid for point sources. Extended sources might require higher value.
+        gain: Optional energy-independent flux scaling, as for
+            [`InstrumentModel`][jaxspec.model.instrument.InstrumentModel] (e.g.
+            [`ConstantGain`][jaxspec.model.instrument.ConstantGain]).
+        shift: Optional energy shift, as for
+            [`InstrumentModel`][jaxspec.model.instrument.InstrumentModel] (e.g.
+            [`ConstantShift`][jaxspec.model.instrument.ConstantShift]).
+        alpha: Grade-morphing parameter : the fraction of piled events that keep a good grade,
+            with the good-grade fraction of an order-``p`` pile-up taken
+            proportional to ``alpha ** (p - 1)``.
+        psf_frac: PSF fraction: only this fraction of the extracted counts is treated for pile-up.
+        frame_time: CCD frame (readout) time in seconds (``EXPTIME`` keyword).
+        frac_expo: Fractional exposure per frame in ``(0, 1]`` (``FRACEXPO`` keyword).
+        g0: Grade correction for single-photon detection.
+        npiled: Maximum number of photons piled up in a single frame
+        num_regions: Number of regions over which the piled counts are distributed, `1` for a point source.
     """
 
     requires_components = True
@@ -234,6 +280,9 @@ class PileupModel(InstrumentModel):
         # (the energy grid is assumed uniform, so the first bin width sets the offset).
         bin_width = in_energies[0, 1] - in_energies[0, 0]
         ioff = -jnp.array(in_energies[0, 0] // bin_width, jnp.int32)
+        # Vectorised offset gather (see below): built once and shared across branches.
+        n_orig = in_energies.shape[1]
+        shift_idx = jnp.arange(n_orig) + ioff
 
         def pileup_fold(s):
             # The pileup math operates on a single spectrum; ``jax.tree.map``
@@ -255,12 +304,14 @@ class PileupModel(InstrumentModel):
             # Normalize to avoid overflow and perform FFT convolutions
             arf_s_tmp = arf_s_tmp / integ_arf_s
             integ_arf_s_n = integ_arf_s  # for renormalization after
-            n_orig = arf_s_tmp.shape[-1]
             arf_s_fft = jnp.fft.rfft(arf_s_tmp)
             factor = 1
 
-            # Compute FFT with offset
-            tmpar = jnp.array([arf_s_tmp[ie + ioff] for ie in range(n_orig)])
+            # Compute FFT with offset. ``arf_s_tmp[shift_idx]`` is the vectorised
+            # equivalent of ``[arf_s_tmp[ie + ioff] for ie in range(n_orig)]`` --
+            # a single gather instead of one op per channel (bit-identical, but a
+            # far smaller XLA graph and much faster to trace/compile).
+            tmpar = arf_s_tmp[shift_idx]
             arf_s_fft_2 = jnp.fft.rfft(tmpar)
 
             # Calculate higher order terms

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -19,7 +19,7 @@ from helpers import (
 from jaxspec.fit import MCMCFitter, NSFitter, TiedParameter, VIFitter
 from jaxspec.model.additive import Powerlaw
 from jaxspec.model.background import BackgroundWithError, SpectralModelBackground
-from jaxspec.model.instrument import ConstantGain, ConstantShift, InstrumentModel
+from jaxspec.model.instrument import ConstantGain, ConstantShift, InstrumentModel, PileupModel
 from jaxspec.model.multiplicative import Tbabs
 from numpyro.optim import optax_to_numpyro
 from optax import adamw
@@ -102,6 +102,39 @@ def test_instrument_model_building(sampler):
             "PN": None,  # explicit reference
             "MOS1": InstrumentModel(gain=ConstantGain(), shift=ConstantShift()),
             "MOS2": InstrumentModel(gain=ConstantGain(), shift=ConstantShift()),
+        },
+    )
+
+    result = forward_model.fit(**SHORT_MCMC_FIT, sampler=sampler)
+    assert_result_smoke(result)
+
+
+@pytest.mark.slow
+@mcmc_marker
+def test_pileup_model_building(sampler):
+    prior_with_instruments = {
+        **prior_shared_pars,
+        "instrument.alpha[*]": dist.Uniform(0.0,1.0),
+        "instrument.psf_frac[*]": dist.Uniform(0.8, 1.0),
+        "instrument.gain.factor[*]": dist.Uniform(0.8, 1.2),
+        "instrument.shift.offset[*]": dist.Uniform(-0.1, +0.1),
+    }
+    
+    pileup_kwargs = {
+    "frac_expo" : 1.0,
+    "frame_time" : 3.1,
+    }
+
+    forward_model = MCMCFitter(
+        spectral_model,
+        prior_with_instruments,
+        dict_of_obsconf,
+        background_model=None,
+        energy_grid = np.arange(0.20, 11 + 0.001, 0.001),
+        instrument_model={
+            "PN": None,  # explicit reference
+            "MOS1": PileupModel(gain=ConstantGain(), shift=ConstantShift(), **pileup_kwargs),
+            "MOS2": PileupModel(gain=ConstantGain(), shift=ConstantShift(), **pileup_kwargs),
         },
     )
 

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -110,19 +110,21 @@ def test_instrument_model_building(sampler):
 
 
 @pytest.mark.slow
-@mcmc_marker
-def test_pileup_model_building(sampler):
+def test_pileup_model_building():
+    # Single-sampler smoke test: pileup prior binding is sampler-independent and
+    # the numerics are covered by the fast tests in ``tests/test_pileup.py``; the
+    # fine energy grid makes tracing the dominant cost, so NUTS alone suffices.
     prior_with_instruments = {
         **prior_shared_pars,
-        "instrument.alpha[*]": dist.Uniform(0.0,1.0),
+        "instrument.alpha[*]": dist.Uniform(0.0, 1.0),
         "instrument.psf_frac[*]": dist.Uniform(0.8, 1.0),
         "instrument.gain.factor[*]": dist.Uniform(0.8, 1.2),
         "instrument.shift.offset[*]": dist.Uniform(-0.1, +0.1),
     }
-    
+
     pileup_kwargs = {
-    "frac_expo" : 1.0,
-    "frame_time" : 3.1,
+        "frac_expo": 1.0,
+        "frame_time": 3.1,
     }
 
     forward_model = MCMCFitter(
@@ -130,7 +132,7 @@ def test_pileup_model_building(sampler):
         prior_with_instruments,
         dict_of_obsconf,
         background_model=None,
-        energy_grid = np.arange(0.20, 11 + 0.001, 0.001),
+        energy_grid=np.arange(0.20, 11 + 0.001, 0.001),
         instrument_model={
             "PN": None,  # explicit reference
             "MOS1": PileupModel(gain=ConstantGain(), shift=ConstantShift(), **pileup_kwargs),
@@ -138,7 +140,7 @@ def test_pileup_model_building(sampler):
         },
     )
 
-    result = forward_model.fit(**SHORT_MCMC_FIT, sampler=sampler)
+    result = forward_model.fit(**SHORT_MCMC_FIT, sampler="nuts")
     assert_result_smoke(result)
 
 

--- a/tests/test_pileup.py
+++ b/tests/test_pileup.py
@@ -1,0 +1,193 @@
+"""Fast, network-free unit tests for :class:`jaxspec.model.instrument.PileupModel`
+(Davis 2001 CCD pileup).
+
+A tiny synthetic instrument response is built in memory via
+``Instrument.from_matrix`` + ``ObsConfiguration.mock_from_instrument`` on a
+uniform energy grid (the grid uniformity is the model's design contract). The
+single real-response smoke test reuses the shared ``single_obsconf``.
+"""
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import sparse
+
+from flax import nnx
+from helpers import single_obsconf
+from jaxspec.data.instrument import Instrument
+from jaxspec.data.obsconf import ObsConfiguration
+from jaxspec.fit._forward_model import ForwardModel, _build_obs_cache
+from jaxspec.model.additive import Powerlaw
+from jaxspec.model.instrument import (
+    ConstantGain,
+    ConstantShift,
+    InstrumentModel,
+    PileupModel,
+)
+
+# Minimal required pileup kwargs (Chandra FRACEXPO / EXPTIME analogues).
+PILEUP_KWARGS = {"frac_expo": 1.0, "frame_time": 3.1}
+
+
+def _synthetic_obsconf(n=40, e_min=0.5, e_max=10.5, area=100.0, exposure=1e4):
+    """A tiny in-memory ObsConfiguration on a uniform grid with an identity RMF."""
+    edges = np.linspace(e_min, e_max, n + 1)
+    e_lo, e_hi = edges[:-1], edges[1:]
+    instrument = Instrument.from_matrix(sparse.eye(n), np.full(n, area), e_lo, e_hi, e_lo, e_hi)
+    return ObsConfiguration.mock_from_instrument(instrument, exposure=exposure)
+
+
+def _powerlaw_flux(obs, norm=1e-2, index=1.5):
+    """A positive per-bin integrated flux on the obs's native (uniform) grid."""
+    in_en = np.asarray(obs.in_energies)
+    mid = 0.5 * (in_en[0] + in_en[1])
+    width = in_en[1] - in_en[0]
+    return jnp.asarray(norm * mid ** (-index) * width)
+
+
+def test_pileup_construction():
+    m = PileupModel(gain=ConstantGain(), shift=ConstantShift(), **PILEUP_KWARGS)
+    assert isinstance(m.alpha, nnx.Param)
+    assert isinstance(m.psf_frac, nnx.Param)
+    assert m.requires_components is True
+    # npiled is coerced to a Python int (guards the range() crash); other
+    # constants resolve to their documented defaults.
+    assert m._constants["npiled"] == 5
+    assert isinstance(m._constants["npiled"], int)
+    assert m._constants["num_regions"] == 1.0
+    assert m._constants["g0"] == 1.0
+    # nnx.split/merge must round-trip the module and preserve the static
+    # (off-tree) constants dict — this is what the MCMC prior binding relies on.
+    merged = nnx.merge(*nnx.split(m))
+    assert merged._constants == m._constants
+
+
+def test_pileup_requires_frame_time():
+    """frame_time / frac_expo are required; omitting either raises at construction
+    rather than dying with a cryptic ``None * array`` deep inside ``fold``."""
+    with pytest.raises(ValueError, match="frame_time"):
+        PileupModel(gain=ConstantGain(), frac_expo=1.0)  # frame_time missing
+    with pytest.raises(ValueError, match="frac_expo"):
+        PileupModel(gain=ConstantGain(), frame_time=3.1)  # frac_expo missing
+
+
+@pytest.mark.parametrize("npiled", [None, 2, 3.0, 5])
+def test_pileup_default_npiled_folds_finite(npiled):
+    """Regression: the default ``npiled`` (a float) used to crash
+    ``range(2, npiled + 1)`` with a ``TypeError``. Fold must return finite,
+    non-negative counts of the right shape for int and float ``npiled`` alike."""
+    obs = _synthetic_obsconf()
+    kwargs = dict(PILEUP_KWARGS)
+    if npiled is not None:
+        kwargs["npiled"] = npiled
+    m = PileupModel(gain=ConstantGain(), shift=ConstantShift(), **kwargs)
+    cache = _build_obs_cache(obs, m, sparse=False)
+    out = m.fold(_powerlaw_flux(obs), cache, eval_energies=jnp.asarray(obs.in_energies))
+
+    assert out.shape == (obs.transfer_matrix.data.shape[0],)
+    assert bool(jnp.all(jnp.isfinite(out)))
+    assert bool(jnp.all(out >= 0))
+
+
+def test_pileup_requires_eval_energies():
+    """``PileupModel.fold`` needs an explicit energy grid; ``None`` raises."""
+    obs = _synthetic_obsconf()
+    m = PileupModel(gain=ConstantGain(), shift=ConstantShift(), **PILEUP_KWARGS)
+    cache = _build_obs_cache(obs, m, sparse=False)
+    with pytest.raises(ValueError, match="energy grid"):
+        m.fold(_powerlaw_flux(obs), cache)
+
+
+def test_pileup_no_pileup_limit_matches_base():
+    """With ``alpha=0``, ``psf_frac=1``, ``frame_time -> 0`` and unit
+    ``num_regions``/``g0``/``frac_expo``, the pileup fold reduces to the base
+    ``transfer_matrix @ spectrum`` fold (the higher-order terms vanish)."""
+    obs = _synthetic_obsconf()
+    flux = _powerlaw_flux(obs)
+    eval_energies = jnp.asarray(obs.in_energies)
+
+    pileup = PileupModel(frac_expo=1.0, frame_time=1e-9, num_regions=1.0, g0=1.0, npiled=5)
+    pileup.alpha = nnx.Param(jnp.asarray(0.0))
+    pileup.psf_frac = nnx.Param(jnp.asarray(1.0))
+    pileup_out = np.asarray(
+        pileup.fold(flux, _build_obs_cache(obs, pileup, sparse=False), eval_energies=eval_energies)
+    )
+
+    base = InstrumentModel()
+    base_out = np.asarray(
+        base.fold(flux, _build_obs_cache(obs, base, sparse=False), eval_energies=eval_energies)
+    )
+
+    mask = base_out > 1e-6  # ignore bins pinned at the base fold's clip floor
+    np.testing.assert_allclose(pileup_out[mask], base_out[mask], rtol=1e-6)
+
+
+def test_pileup_reduces_counts():
+    """A bright source piles up: total counts drop vs the no-pileup reference,
+    and a longer frame time causes at least as much loss."""
+    obs = _synthetic_obsconf()
+    bright = _powerlaw_flux(obs, norm=50.0)
+    eval_energies = jnp.asarray(obs.in_energies)
+
+    def total(frame_time):
+        m = PileupModel(frac_expo=1.0, frame_time=frame_time, npiled=5)
+        cache = _build_obs_cache(obs, m, sparse=False)
+        return float(jnp.sum(m.fold(bright, cache, eval_energies=eval_energies)))
+
+    no_pileup = total(1e-9)  # negligible frame time -> negligible pileup
+    mild = total(1.0)
+    strong = total(3.0)
+
+    assert mild < no_pileup  # pileup removes / migrates counts
+    assert strong <= mild + 1e-6  # more frame time -> at least as much loss
+
+
+def test_pileup_split_branches_fold():
+    """Posterior-predictive overlays fold a *dict* of per-branch spectra;
+    ``fold`` must map the pileup math over the pytree instead of assuming a
+    single array (regression for the ``'dict' * BatchTracer`` crash)."""
+    obs = _synthetic_obsconf()
+    m = PileupModel(gain=ConstantGain(), shift=ConstantShift(), **PILEUP_KWARGS)
+    cache = _build_obs_cache(obs, m, sparse=False)
+    flux = _powerlaw_flux(obs)
+    branches = {"powerlaw_1": flux, "blackbodyrad_1": 0.5 * flux}
+
+    out = m.fold(branches, cache, eval_energies=jnp.asarray(obs.in_energies))
+
+    assert set(out) == set(branches)
+    n_channels = obs.transfer_matrix.data.shape[0]
+    for arr in out.values():
+        assert arr.shape == (n_channels,)
+        assert bool(jnp.all(jnp.isfinite(arr)))
+        assert bool(jnp.all(arr >= 0))
+
+
+def test_pileup_real_response_smoke():
+    """Fold a default ``PileupModel`` through the real XMM response end-to-end
+    via ``ForwardModel.evaluate`` (exercises the real redistribution/grouping/
+    area/exposure matrices and the ``ioff``/``tmpar``/``int32`` path)."""
+    obs = single_obsconf
+    native = np.asarray(obs.in_energies)
+    grid = np.linspace(max(native.min(), 1e-2), native.max(), 4000)
+
+    fm = ForwardModel(
+        Powerlaw(),
+        obs,
+        instrument_model={
+            "data": PileupModel(gain=ConstantGain(), shift=ConstantShift(), **PILEUP_KWARGS)
+        },
+        energy_grid=grid,
+    )
+    inputs = {
+        "spectrum.data.powerlaw_1.alpha": jnp.asarray(1.7),
+        "spectrum.data.powerlaw_1.norm": jnp.asarray(1e-3),
+        "instrument.data.alpha": jnp.asarray(0.5),
+        "instrument.data.psf_frac": jnp.asarray(0.95),
+        "instrument.data.gain.factor": jnp.asarray(1.0),
+        "instrument.data.shift.offset": jnp.asarray(0.0),
+    }
+    out = fm.evaluate(inputs)["data"]["source"]
+
+    assert out.ndim == 1 and out.shape[0] > 0
+    assert bool(jnp.all(jnp.isfinite(out)))
+    assert bool(jnp.all(out >= 0))


### PR DESCRIPTION
I added the pileup computation as a subclass of the InstrumentModel. The pileup model was tested against XSPEC for a powerlaw, BB and NSatmos models.

<!-- readthedocs-preview jaxspec start -->
----
📚 Documentation preview 📚: https://jaxspec--277.org.readthedocs.build/en/277/

<!-- readthedocs-preview jaxspec end -->